### PR TITLE
Don't allow tick eating Zuk hits

### DIFF
--- a/src/sdk/Player.ts
+++ b/src/sdk/Player.ts
@@ -821,6 +821,8 @@ export class Player extends Unit {
     super.attackStep();
     this.detectDeath();
 
+    this.eats.tickFood(this);
+
     this.processIncomingAttacks();
 
     if (this.dying > -1) {
@@ -835,8 +837,6 @@ export class Player extends Unit {
     }
 
     this.attackIfPossible();
-
-    this.eats.tickFood(this);
 
     this.regenTimer.regen();
 

--- a/src/sdk/weapons/Projectile.ts
+++ b/src/sdk/weapons/Projectile.ts
@@ -54,6 +54,7 @@ export interface ProjectileOptions {
   offsetsInterpolator?: MultiModelProjectileOffsetInterpolator;
   // offset of start height
   verticalOffset?: number;
+  rollDamageOnHit?: boolean;
 }
 
 const targetIsLocation = (x: Unit | Location): x is Location => (x as Location).x !== undefined;

--- a/src/sdk/weapons/Projectile.ts
+++ b/src/sdk/weapons/Projectile.ts
@@ -84,7 +84,7 @@ export class Projectile extends Renderable {
     This should take the player and mob object, and do chebyshev on the size of them
   */
   constructor(
-    private weapon: Weapon | null,
+    protected weapon: Weapon | null,
     damage: number,
     from: Unit,
     to: Unit | Location3,


### PR DESCRIPTION
Had to move `this.eats.tickFood(this);` above `this.eats.tickFood(this);` as even with the change in logic to scan damage when the attack lands, I was still able to tick eat if I performed the eat on the same tick that the projectile landed, this change fixes that, However, since I didn't originally write this function, I am not 100% aware of the reason it was in this order to begin with and hence the side effects that this could have, so this part particularly needs consideration.

Requires:
https://github.com/OldSchoolSDK/InfernoTrainer/pull/305