### PR TITLE
refactor: Region now returns renderable children, rather than having Viewport determine what is renderable

### DIFF
--- a/src/sdk/Region.ts
+++ b/src/sdk/Region.ts
@@ -103,6 +103,7 @@ export abstract class Region {
   }
 
   removeMob(mob: Mob) {
+    mob.dying = 0;
     remove(this.mobs, mob);
   }
 

--- a/src/sdk/Region.ts
+++ b/src/sdk/Region.ts
@@ -5,6 +5,7 @@ import type { Entity } from "./Entity";
 import type { Item } from "./Item";
 import type { Mob } from "./Mob";
 import type { Player } from "./Player";
+import type { Renderable } from "./Renderable";
 import { Settings } from "./Settings";
 import type { World } from "./World";
 import type { Projectile } from "./weapons/Projectile";
@@ -89,7 +90,6 @@ export abstract class Region {
   }
 
   removeEntity(entity: Entity) {
-    entity.dying = 0;
     remove(this.entities, entity);
   }
 
@@ -103,8 +103,8 @@ export abstract class Region {
   }
 
   removeMob(mob: Mob) {
-    mob.dying = 0;
     remove(this.mobs, mob);
+    remove(this.newMobs, mob);
   }
 
   removePlayer(player: Player) {
@@ -223,5 +223,13 @@ export abstract class Region {
     await Promise.all(this.mobs.map((mob) => mob.preload()));
     await Promise.all(this.newMobs.map((mob) => mob.preload()));
     await Promise.all(this.players.map((players) => players.preload()));
+  }
+
+  getRenderables(): Renderable[] {
+    const units = [...this.players, ...this.mobs, ...this.newMobs];
+    const incomingProjectiles: Renderable[] = [];
+    units.forEach((unit) => incomingProjectiles.push(...unit.incomingProjectiles));
+
+    return [...this.entities, ...units, ...this.projectiles, ...incomingProjectiles];
   }
 }

--- a/src/sdk/Viewport3d.ts
+++ b/src/sdk/Viewport3d.ts
@@ -10,13 +10,11 @@ import { Chrome } from "./Chrome";
 import { Settings } from "./Settings";
 import { Player } from "./Player";
 import { Mob } from "./Mob";
-import { Entity } from "./Entity";
 import { Renderable } from "./Renderable";
 import { Location } from "./Location";
 import { Actor } from "./rendering/Actor";
 import _ from "lodash";
 import { Unit } from "./Unit";
-import { Projectile } from "./weapons/Projectile";
 import { Trainer } from "./Trainer";
 import { Pathing } from "./Pathing";
 
@@ -384,70 +382,24 @@ export class Viewport3d implements ViewportDelegate {
   }
 
   draw3dScene(world: World, region: Region) {
-    // create actors
-    region.entities.forEach((entity: Entity) => {
-      let actor = this.knownActors.get(entity);
-      if (!actor) {
-        actor = new Actor(entity);
-        this.knownActors.set(entity, actor);
-      }
-    });
+    this.reconcileActors(region);
 
-    const projectiles: Projectile[] = [];
     region.players.forEach((player: Player) => {
-      let actor = this.knownActors.get(player);
-      if (!actor) {
-        actor = new Actor(player);
-        this.knownActors.set(player, actor);
+      const actor = this.knownActors.get(player);
+      const model = actor?.getModel();
+      if (!model) {
+        return;
       }
       // Update the camera position relative to the player's mesh
       const v = new THREE.Vector3(0.5, 0, -0.5);
-      v.add(actor.getModel().getWorldPosition());
+      v.add(model.getWorldPosition());
       this.pivot.position.lerp(v, 5 / world.fps);
-      // Add all projectiles to scene
-      projectiles.push(...player.incomingProjectiles);
-    });
-
-    region.mobs.concat(region.newMobs).forEach((mob: Mob) => {
-      let actor = this.knownActors.get(mob);
-      if (!actor) {
-        actor = new Actor(mob);
-        this.knownActors.set(mob, actor);
-      }
-      // Add all projectiles to scene
-      projectiles.push(...mob.incomingProjectiles);
-    });
-
-    region.projectiles.forEach((projectile: Projectile) => {
-      let actor = this.knownActors.get(projectile);
-      if (!actor) {
-        actor = new Actor(projectile);
-        this.knownActors.set(projectile, actor);
-      }
-      // Add all projectiles to scene
-      projectiles.push(projectile);
-    });
-
-    projectiles.forEach((projectile) => {
-      let actor = this.knownActors.get(projectile);
-      if (!actor) {
-        actor = new Actor(projectile);
-        this.knownActors.set(projectile, actor);
-      }
     });
 
     const delta = this.clock.getDelta();
     this.updateCamera(delta);
 
-    this.knownActors.forEach((actor, entity) => {
-      if (actor.shouldRemove()) {
-        // remove destroyed actors
-        actor.destroy(this.scene);
-        this.knownActors.delete(entity);
-      } else {
-        actor.draw(this.scene, delta, world.tickPercent);
-      }
-    });
+    this.knownActors.forEach((actor) => actor.draw(this.scene, delta, world.tickPercent));
 
     // highlight selected tile
     if (this.selectedTile) {
@@ -456,6 +408,23 @@ export class Viewport3d implements ViewportDelegate {
       this.selectedTileMesh.position.z = this.selectedTile.y - 0.5;
       this.selectedTileMesh.visible = !Trainer.clickController.hasSelectedMob();
     }
+  }
+
+  private reconcileActors(region: Region) {
+    const activeRenderables = new Set(region.getRenderables());
+
+    this.knownActors.forEach((actor, renderable) => {
+      if (!activeRenderables.has(renderable) || actor.shouldRemove()) {
+        actor.destroy(this.scene);
+        this.knownActors.delete(renderable);
+      }
+    });
+
+    activeRenderables.forEach((renderable) => {
+      if (!renderable.shouldDestroy() && !this.knownActors.has(renderable)) {
+        this.knownActors.set(renderable, new Actor(renderable));
+      }
+    });
   }
 
   draw2dScene(world: World, region: Region) {

--- a/test/sdk/Region.test.ts
+++ b/test/sdk/Region.test.ts
@@ -1,0 +1,61 @@
+import { Entity } from "../../src/sdk/Entity";
+import { Player } from "../../src/sdk/Player";
+import { Viewport } from "../../src/sdk/Viewport";
+import { World } from "../../src/sdk/World";
+import { TestNpc } from "../../src/sdk/testing/TestNpc";
+import { TestRegion } from "../../src/sdk/testing/TestRegion";
+import { Projectile } from "../../src/sdk/weapons/Projectile";
+
+describe("region lifecycle", () => {
+  test("removing a mob from newMobs works before it is promoted to mobs", () => {
+    const region = new TestRegion(10, 10);
+    region.world = new World();
+    const mob = new TestNpc(region, { x: 5, y: 5 }, {});
+    region.addMob(mob);
+
+    expect(region.newMobs).toContain(mob);
+
+    region.removeMob(mob);
+
+    expect(region.newMobs).not.toContain(mob);
+    expect(region.mobs).not.toContain(mob);
+  });
+
+  test("getRenderables returns region-owned renderables and unit projectiles", () => {
+    const region = new TestRegion(10, 10);
+    const entity = new Entity(region, { x: 1, y: 1 });
+    const player = new Player(region, { x: 2, y: 2 });
+    const mob = new TestNpc(region, { x: 5, y: 5 }, {});
+    const queuedMob = new TestNpc(region, { x: 6, y: 6 }, {});
+    const regionProjectile = new Projectile(null, 0, player, { x: 3, y: 3, z: 0 }, "range");
+    const incomingProjectile = new Projectile(null, 0, mob, player, "range");
+
+    region.addEntity(entity);
+    region.addPlayer(player);
+    region.mobs.push(mob);
+    region.newMobs.push(queuedMob);
+    region.projectiles.push(regionProjectile);
+    mob.incomingProjectiles.push(incomingProjectile);
+
+    const renderables = region.getRenderables();
+
+    expect(renderables).toEqual(
+      expect.arrayContaining([entity, player, mob, queuedMob, regionProjectile, incomingProjectile]),
+    );
+  });
+
+  test("world cleanup still removes mobs whose death state has completed", () => {
+    const region = new TestRegion(10, 10);
+    const world = new World();
+    const mob = new TestNpc(region, { x: 5, y: 5 }, {});
+    region.addMob(mob);
+    region.world = world;
+    world.addRegion(region);
+    mob.dying = 0;
+    Viewport.viewport = { tick: jest.fn() } as never;
+
+    world.tickRegion(region);
+
+    expect(region.mobs).not.toContain(mob);
+  });
+});


### PR DESCRIPTION
The abstraction between units (/mobs) and the graphics are was a bit broken.

The Viewport3d had a lot of Region-specific business logic in it, where it was iterating over the Region's children to figure out what to create Actors for. Not only does this mean the Viewport had to know everything about the Region's children, but also the Region had no way of removing stuff from the scene once those actors were created. Ergo we had to mutate the Mob (e.g. set `this.dying = 0`) to get it to remove itself from the scene.

What makes more sense is for a Region to advertise exactly what is renderable.

Now this means, to remove something from the scene, you just remove it from the Region so the Region stops advertising it.

Disclaimer: used Codex for a second pass at this, learning how to use AI 😅  but every change is manually reviewed.